### PR TITLE
GraphQL query naming & darkmode logo invert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/
 npm-debug.log
 .eslintcache
 .gatsby-context.js
+src/gatsby-types.d.ts

--- a/content/posts/2021-03-31-Unsplash Next.js Search.md
+++ b/content/posts/2021-03-31-Unsplash Next.js Search.md
@@ -16,7 +16,7 @@ tags:
 image:
 ---
 
-<p class="text-center"><img class="inline" src="/media/images/nextjs-logo.svg" alt="nextjs_logo" width="30%"><br/><img class="inline" src="/media/images/2019/05/unsplash.svg" alt="unsplash-logo" width="13%"></p>
+<p class="text-center"><img class="inline dark-logo" src="/media/images/nextjs-logo.svg" alt="nextjs_logo" width="30%"><br/><img class="inline dark-logo" src="/media/images/2019/05/unsplash.svg" alt="unsplash-logo" width="13%"></p>
 
 This is a working example of a next.js app using state to render an array of images utilizing the virtual DOM.<br/>
 The project also uses the `fetch()` api which provides asynchronous requests with the use of promises.<br/>

--- a/content/posts/2022-10-21-Image Search Using Sveltekit.md
+++ b/content/posts/2022-10-21-Image Search Using Sveltekit.md
@@ -14,7 +14,7 @@ tags:
 image:
 ---
 
-<p class="text-center"><img class="inline" src="/media/logos/svelte.svg" alt="sveltekit_logo" width="15%"> <img class="inline" src="/media/images/2019/05/unsplash.svg" alt="unsplash-logo" width="15%"></p>
+<p class="text-center"><img class="inline" src="/media/logos/svelte.svg" alt="sveltekit_logo" width="15%"> <img class="inline dark-logo" src="/media/images/2019/05/unsplash.svg" alt="unsplash-logo" width="15%"></p>
 
 This is a example of a sveltekit app which renders an array of images from the unsplash json api utilizing some features of sveltekit.
 

--- a/node/createPages.ts
+++ b/node/createPages.ts
@@ -42,7 +42,7 @@ export const createPages = async ({ graphql, actions }) => {
    * Query for Posts & Pages
    */
   const result = await graphql(`
-    {
+    query nonDraftQuery {
       allMarkdownRemark(filter: { frontmatter: { draft: { ne: true } } }) {
         edges {
           node {

--- a/node/pagination/createPostsPages.ts
+++ b/node/pagination/createPostsPages.ts
@@ -6,7 +6,7 @@ export const createPostsPages = async (graphql, actions) => {
   const { createPage } = actions
 
   const result = await graphql(`
-    {
+    query postCountQuery {
       allMarkdownRemark(filter: { frontmatter: { template: { ne: "page" }, draft: { ne: true } } }) {
         totalCount
       }

--- a/node/pagination/createTagsPages.ts
+++ b/node/pagination/createTagsPages.ts
@@ -8,7 +8,7 @@ export const createTagsPages = async (graphql, actions) => {
   const { postsPerPage } = siteConfig
 
   const result = await graphql(`
-    {
+    query tagCountQuery {
       allMarkdownRemark(filter: { frontmatter: { template: { ne: "page" }, draft: { ne: true } } }) {
         group(field: frontmatter___tags) {
           fieldValue

--- a/src/assets/scss/themes/overrides.css
+++ b/src/assets/scss/themes/overrides.css
@@ -205,3 +205,7 @@ a.github:hover {
     padding: 0 10px;
     font-size: 1.2em;
 }
+
+.dark-mode img.dark-logo {
+    filter: invert(1);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true
   },
-  "exclude": ["node_modules", "public", ".cache"]
+  "exclude": ["node_modules", "public", ".cache"],
+  "include": ["./src/**/*", "./gatsby-node.ts", "./gatsby-config.ts", "./node/**/*"]
 }


### PR DESCRIPTION
- [x] named all graphql queries
- [x] added css override to invert dark logos in darkmode

* 485b6fc added class dark-logo to nextjs & unsplash logos in article
* 22b4481 added gatsby-types.d.ts to gitignore
* c5b10bd updated tsconfig with new includes & linted
* 6172003 named graphql query nonDraftQuery in createPages
* 8098d2a named graphql query postCountQuery for pagination
* ea61f77 named graphql query tagCountQuery for pagination
* 060efac added class dark-logo fo unsplash logo in sveltekit image search article
* a6cf381 added css override to invert dark logos in darkmode
